### PR TITLE
Refine post-processing method

### DIFF
--- a/Source/MazeGenerator/Public/Maze.h
+++ b/Source/MazeGenerator/Public/Maze.h
@@ -205,7 +205,8 @@ protected:
         // Destroys all spawned AStaticMeshActor cells.
         virtual void ClearMaze();
 
-	virtual FVector2D GetMaxCellSize() const;
+        virtual FVector2D GetMaxCellSize() const;
+       virtual void PostProcessLoopsAndRooms();
 
 
 #if WITH_EDITOR


### PR DESCRIPTION
## Summary
- remove call to `PostProcessLoopsAndRooms` from `UpdateMaze`
- keep deterministic RNG in `PostProcessLoopsAndRooms`
- restore header formatting and declaration

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68584041a928832cb32513aeee45a732