### PR TITLE
Fix FMazeCoordinates TPair operator

### DIFF
--- a/Source/MazeGenerator/Private/Maze.cpp
+++ b/Source/MazeGenerator/Private/Maze.cpp
@@ -55,9 +55,9 @@ bool FMazeCoordinates::operator!=(const FMazeCoordinates& Other) const
 	return !(*this == Other);
 }
 
-FMazeCoordinates::operator TTuple<int, int>() const
+TPair<int32, int32> FMazeCoordinates::operator TPair<int32, int32>() const
 {
-	return TPair<int32, int32>{X, Y};
+        return {X, Y};
 }
 
 AMaze::AMaze()


### PR DESCRIPTION
## Summary
- match FMazeCoordinates cast operator definition with the header

## Testing
- `echo "No tests defined" && true`


------
https://chatgpt.com/codex/tasks/task_e_6858f2918af0832ca5d011dc0fc83eea