### PR TITLE
Fix conversion operator definition

### DIFF
--- a/Source/MazeGenerator/Private/Maze.cpp
+++ b/Source/MazeGenerator/Private/Maze.cpp
@@ -55,7 +55,7 @@ bool FMazeCoordinates::operator!=(const FMazeCoordinates& Other) const
 	return !(*this == Other);
 }
 
-TPair<int32, int32> FMazeCoordinates::operator TPair<int32, int32>() const
+FMazeCoordinates::operator TPair<int32, int32>() const
 {
         return {X, Y};
 }


### PR DESCRIPTION
## Summary
- fix conversion operator syntax for FMazeCoordinates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858fabdd26c832ca99b6d9015154d57