### PR TITLE
Enable automation test access to Maze internals

### DIFF
--- a/Source/MazeGenerator/Public/Maze.h
+++ b/Source/MazeGenerator/Public/Maze.h
@@ -65,14 +65,20 @@ struct FMazeCoordinates
 
 class Algorithm;
 class AStaticMeshActor;
+#if WITH_DEV_AUTOMATION_TESTS
+class FMazeLoopFactorTest;
+#endif
 
 UCLASS()
 class MAZEGENERATOR_API AMaze : public AActor
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
+#if WITH_DEV_AUTOMATION_TESTS
+        friend class FMazeLoopFactorTest;
+#endif
 
 public:
-	AMaze();
+        AMaze();
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Maze",
 		meta=(NoResetToDefault, ExposeOnSpawn, DisplayPriority=0))


### PR DESCRIPTION
## Summary
- grant Maze automation tests access to protected members

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6858fc531f50832c974a2993b0f2ab1a